### PR TITLE
feat(p2): add Vagrant VM and K3s server startup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help p1-up p1-down p1-status p1-clean p1-ssh-server p1-ssh-worker
+.PHONY: help p1-up p1-down p1-status p1-clean p1-ssh-server p1-ssh-worker \
+	p2-up p2-down p2-status p2-clean p2-ssh-server
 .DEFAULT_GOAL := help
 
 help:
@@ -6,6 +7,7 @@ help:
 	@echo ""
 	@echo "Quick Start:"
 	@echo "  make p1-up        - Start Part 1 K3S cluster (full automation)"
+	@echo "  make p2-up        - Start Part 2 K3S server (full automation)"
 	@echo ""
 	@echo "Part 1 Targets:"
 	@echo "  make p1-up         - Start K3S cluster with 2 nodes (master + worker)"
@@ -15,8 +17,15 @@ help:
 	@echo "  make p1-ssh-server - SSH into K3S master"
 	@echo "  make p1-ssh-worker - SSH into K3S worker"
 	@echo ""
-	@echo "After 'make p1-up', verify with:"
-	@echo "  make p1-ssh-server"
+	@echo "Part 2 Targets:"
+	@echo "  make p2-up         - Start the VM with K3S in server mode"
+	@echo "  make p2-down       - Stop Part 2 VM"
+	@echo "  make p2-status     - Show Part 2 VM status"
+	@echo "  make p2-clean      - Destroy Part 2 VM and clean state"
+	@echo "  make p2-ssh-server - SSH into K3S server"
+	@echo ""
+	@echo "After 'make p1-up' / 'make p2-up', verify with:"
+	@echo "  make p1-ssh-server   (or p2-ssh-server)"
 	@echo "  kubectl get nodes"
 
 p1-up:
@@ -36,3 +45,18 @@ p1-ssh-server:
 
 p1-ssh-worker:
 	@$(MAKE) -C p1 ssh-worker
+
+p2-up:
+	@$(MAKE) -C p2 up
+
+p2-down:
+	@$(MAKE) -C p2 down
+
+p2-status:
+	@$(MAKE) -C p2 status
+
+p2-clean:
+	@$(MAKE) -C p2 clean
+
+p2-ssh-server:
+	@$(MAKE) -C p2 ssh-server

--- a/p2/Makefile
+++ b/p2/Makefile
@@ -1,0 +1,43 @@
+.PHONY: up down status clean ssh-server reload help
+.DEFAULT_GOAL := help
+
+MACHINE_NAME_S := gfontao-S
+
+
+up:
+	@echo "Starting K3S Cluster with Vagrant..."
+	@echo "This may take 5-15 minutes on first run."
+	@echo "Do NOT interrupt this process."
+	@echo ""
+	VAGRANT_DEFAULT_PROVIDER=virtualbox vagrant up
+
+down:
+	vagrant halt
+
+status:
+	vagrant status
+
+clean:
+	@vagrant destroy -f 2>/dev/null || true
+	@rm -rf .vagrant
+
+ssh-server:
+	vagrant ssh $(MACHINE_NAME_S)
+
+reload:
+	vagrant reload
+
+help:
+	@echo "Part 2: K3S Server + three applications"
+	@echo ""
+	@echo "Quick start:"
+	@echo "  make up           - Start the K3S server VM (one command, full automation)"
+	@echo ""
+	@echo "All targets:"
+	@echo "  make up           - Start the VM with K3S in server mode"
+	@echo "  make down         - Stop the VM"
+	@echo "  make status       - Show VM status"
+	@echo "  make clean        - Destroy VM and clean state"
+	@echo "  make ssh-server   - SSH into K3S server ($(MACHINE_NAME_S))"
+	@echo "  make reload       - Reload and re-provision the VM"
+	@echo "  make help         - Show this help"

--- a/p2/Vagrantfile
+++ b/p2/Vagrantfile
@@ -1,0 +1,17 @@
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "bento/debian-13"
+  config.vm.boot_timeout = 600
+
+  config.vm.define "gfontao-S" do |gfontao_S|
+    gfontao_S.vm.hostname = "gfontao-S"
+    gfontao_S.vm.network "private_network", ip: "192.168.56.110"
+    gfontao_S.vm.provider "virtualbox" do |vb|
+      vb.memory = "1024"
+      vb.cpus = 1
+      vb.name = "p2_gfontao-S"
+    end
+    gfontao_S.vm.provision "shell", path: "scripts/server.sh"
+  end
+
+end

--- a/p2/scripts/server.sh
+++ b/p2/scripts/server.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+apt-get update -qq
+apt-get install -y -q curl
+
+IFACE=$(ip -o -4 addr show | awk '/192\.168\.56\.110/ {print $2}')
+
+curl -sfL https://get.k3s.io | \
+  K3S_KUBECONFIG_MODE="644" \
+  INSTALL_K3S_EXEC="--node-ip=192.168.56.110 --flannel-iface=${IFACE}" \
+  sh -


### PR DESCRIPTION
Set up the Part 2 infrastructure: a single Vagrant VM running K3s in server mode at 192.168.56.110.

- Vagrantfile: single node gfontao-S, private network, 1GB RAM
- scripts/server.sh: installs K3s in server mode, auto-detects the network interface bound to 192.168.56.110 for --flannel-iface
- p2/Makefile: p2-specific up/down/status/clean/ssh-server targets
- root Makefile: p2-* passthrough targets

Closes #13

## Linked Issue
Closes #

## Description
What does this PR change?

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

## How was this tested?
Explain validation steps.

## Checklist
- [ ] Code tested locally
- [ ] No breaking changes
- [ ] Documentation updated

Closing #14